### PR TITLE
Add reference to OpenRIF Contribution Role Ontology in section 4.3

### DIFF
--- a/sc-principles/software-citation-principles.bib
+++ b/sc-principles/software-citation-principles.bib
@@ -415,3 +415,11 @@
     Month = sep,
     Year = {2015},
     }
+    
+@article{Gutzman2016,
+    author = "Karen  Gutzman and Stacy Konkiel and Marijane White and Matthew Brush and Violeta Ilik and Michael Conlon and Melissa Haendel and Kristi Holmes",
+    title = "{Attribution of Work in the Scholarly Ecosystem}",
+    year = "2016",
+    month = "4",
+    url = "10.6084/m9.figshare.3175198.v1",
+    }

--- a/sc-principles/software-citation-principles.tex
+++ b/sc-principles/software-citation-principles.tex
@@ -511,7 +511,7 @@ Content specifications for software metadata vary across communities, and
 include DOAP~\cite{DOAP}, an early metadata
 term set used by the Open Source Community, as well as more recent community
 efforts like Research Objects~\cite{Bechhofer2013599}, The Software Ontology~\cite{Malone2014}, EDAM Ontology~\cite{Ison15052013}, Project
-CRediT~\cite{casrai-credit}, Ontosoft~\cite{ontosoft}, RRR\slash JISC guidelines~\cite{JISC2015}, 
+CRediT~\cite{casrai-credit}, the OpenRIF Contribution Role Ontology~\cite{Gutzman2016}, Ontosoft~\cite{ontosoft}, RRR\slash JISC guidelines~\cite{JISC2015}, 
 or the terms and classes defined at \href{https://schema.org}{Schema.org} related to the
 \href{https://schema.org/SoftwareApplication}{\texttt{SoftwareApplication}} class.   In addition,
 language-specific software metadata schemes are in widespread use, including the Debian


### PR DESCRIPTION
Per #85, add a reference in section 4.3 to the OpenRIF Contribution Role Ontology, which expands the roles defined by Project CRediT to other contribution types, and add the bibliographic information for the poster presented at FORCE2016 that describes the ontology and it's development.
